### PR TITLE
Use HTTPS for git URL

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,8 +7,8 @@ let package = Package(
     .library(name: "Stencil", targets: ["Stencil"]),
   ],
   dependencies: [
-    .package(url:"git@github.com:PoissonBallon/PathKit.git", .branch("master")),
-    .package(url:"https://github.com/kylef/Spectre.git", .upToNextMinor(from:"0.8.0"))
+    .package(url: "https://github.com/PoissonBallon/PathKit.git", .branch("master")),
+    .package(url: "https://github.com/kylef/Spectre.git", .upToNextMinor(from:"0.8.0"))
   ],
   targets: [
     .target(name: "Stencil", dependencies: ["PathKit"], path: "Sources"),


### PR DESCRIPTION
Travis-CI does not seem to like "git@github.com" repo URLs when using Swift Package Manager.
Builds timeout after 10min of no output.

See <https://travis-ci.org/gnosis/bivrost-swift/builds/286097608> for the build stall.

Changing it to HTTPS URLs works when using travis. See <https://travis-ci.org/gnosis/bivrost-swift/builds/286451087> for the successful build.

I am opening this PR here as you already have a SPM4 PathKit fork which I use (with the open PR waiting). I could not find a PR for your SPM4 change in the Stencil repo though. 

If you prefer I open this PR (including your change) directly to kylef/Stencil, I will do so. 